### PR TITLE
Warn if the window size is wrong

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -652,6 +652,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Make everything visible
         win.add(&layout_stack);
         win.show_all();
+
+        let size = win.get_size();
+        if size != (config.hardware.screen_x, config.hardware.screen_y) {
+            error!(
+                "Window size is wrong. Current: {:?}, Expected: {:?}",
+                size,
+                (config.hardware.screen_x, config.hardware.screen_y)
+            );
+        }
     });
 
     // Actually run the program


### PR DESCRIPTION
This will only check when the window is first created, other screens in the stack may cause the window size to change without exposing this warning.